### PR TITLE
Adapt Ken's update + empirical formulas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ MyScripts
 Doc
 Tedstone*
 *.bak
+tmp
+myGraph.xml

--- a/README.org
+++ b/README.org
@@ -30,6 +30,8 @@ In more detail:
   + Reproject to EPSG:3413
   + Combine all the files from to form a mosaic using
   + When scenes overlap, selection criteria is "minumum SZA"
+The GNU parallel function will be needed. Install it with the command (Tange (2011): GNU Parallel - The Command-Line Power Tool;login: The USENIX Magazine, February 2011:42-47.)
+sudo apt install parallel
 
 * Debugging & Testing
 
@@ -493,4 +495,23 @@ org.esa.s1tbx.s1tbx.op.calibration                 7.0.0.0  Enabled
 org.netbeans.libs.jsr223                           1.35.1   Installed
 -------------------------------------------------- -------- ---------
 #+end_example
+
+
+Reference:
+@article{Tange2011a,
+  title = {GNU Parallel - The Command-Line Power Tool},
+  author = {O. Tange},
+  address = {Frederiksberg, Denmark},
+  journal = {;login: The USENIX Magazine},
+  month = {Feb},
+  number = {1},
+  volume = {36},
+  url = {http://www.gnu.org/s/parallel},
+  year = {2011},
+  pages = {42-47},
+  doi = {http://dx.doi.org/10.5281/zenodo.16303}
+}
+If you send a copy of your published article to tange@gnu.org, it will be
+mentioned in the release notes of next version of GNU Parallel.
+
 

--- a/S3_proc.sh
+++ b/S3_proc.sh
@@ -94,14 +94,17 @@ for folder in $(ls ${INPATH}); do
     MSG_OK "renaming..."
     for f in $(ls ${DEST}/*_x*); do mv ${f} "${f//_x}"; done
 
+	MSG_OK "Compressing: Start"
+	for f in $(ls ${DEST}); do
+	echo $f
+		gdal_translate -co "COMPRESS=DEFLATE" ${DEST}/${f} ${DEST}/${f}_tmp.tif
+		mv  ${DEST}/${f}_tmp.tif ${DEST}/${f}
+	done
+
     timing
 	if [ -z $CSV ]; then
-	    MSG_OK "Compressing: Start"
-		for f in $(ls ${DEST}); do
-    		echo $f
-    		gdal_translate -co "COMPRESS=DEFLATE" ${DEST}/${f} ${DEST}/${f}_tmp.tif
-    		mv  ${DEST}/${f}_tmp.tif ${DEST}/${f}
-		done
+		MSG_OK "generating tiffs"
+
 	else
 		# input for sice
 		# ns,alat,alon,sza,vza,saa,vaa,height,(toa(iks),iks=1,21)

--- a/dm.grass.sh
+++ b/dm.grass.sh
@@ -18,12 +18,13 @@ for SCENE in ${SCENES}; do
     g.mapset -c ${SCENE} --quiet
     FILES=$(ls ${INFOLDER}/${SCENE}/*.tif)
     echo "Fixing NODATA values for ${SCENE}"
-    parallel --bar "gdalwarp -q -srcnodata -999 {} ./tmp/{%}.tif; mv ./tmp/{%}.tif {}" ::: ${FILES}
+    parallel  --bar "gdalwarp -q  -s_srs EPSG:3413 -srcnodata -999 {} ./tmp/{%}.tif; mv ./tmp/{%}.tif {}" ::: ${FILES}
     echo "Importing data for ${SCENE}"
-    parallel "r.external source={} output={/.} --quiet --o" ::: ${FILES}
+    parallel  "r.external source={} output={/.} --quiet --o" ::: ${FILES}
 
     # SZA cloud masked (CM)
     echo "Masking clouds in SZA rasters"
+    r.mapcalc "SZA_CM = SZA" --o --q
     r.mapcalc "SZA_CM = if(idepix_cloud_ambiguous == 255, null(), SZA)" --o --q
 done
 
@@ -54,7 +55,7 @@ n_imgs=$(echo $SZA_LUT_idxs |wc -w)
 
 # generate a raster of nulls that we can then patch into
 echo "Initializing mosaic scenes..."
-parallel --bar "r.mapcalc \"{} = null()\" --o --q" ::: ${BANDS}
+parallel  --bar "r.mapcalc \"{} = null()\" --o --q" ::: ${BANDS}
 
 ### REFERENCE LOOP VERSION
 # # Patch each BAND based on the minimum SZA_LUT
@@ -75,18 +76,33 @@ doit() {
 }
 export -f doit
 for i in $SZA_LUT_idxs; do
-    parallel --bar doit ${i} ::: ${BANDS}
+    parallel  --bar doit ${i} ::: ${BANDS}
 done
-
 
 echo "Writing mosaics to disk..."
 TIFOPTS='type=Float32 createopt=COMPRESS=DEFLATE,PREDICTOR=2,TILED=YES --q --o'
-parallel "r.colors map={} color=grey --q" ::: ${BANDS} # grayscale
-parallel --bar "r.null map={} setnull=inf --q" ::: ${BANDS}  # set inf to null
-parallel --bar "r.out.gdal -m -c input={} output=${OUTFOLDER}/${DATE}/{}.tif ${TIFOPTS}" ::: ${BANDS}
+parallel  "r.colors map={} color=grey --q" ::: ${BANDS} # grayscale
+parallel  --bar "r.null map={} setnull=inf --q" ::: ${BANDS}  # set inf to null
+parallel  --bar "r.out.gdal -m -c input={} output=${OUTFOLDER}/${DATE}/{}.tif ${TIFOPTS}" ::: ${BANDS}
+
+# Loading the mosaics
+r.external input=${OUTFOLDER}/${DATE}/Oa01_reflectance.tif output=Oa01_reflectance --o --quiet
+r.external input=${OUTFOLDER}/${DATE}/Oa06_reflectance.tif output=Oa06_reflectance --o --quiet
+r.external input=${OUTFOLDER}/${DATE}/Oa10_reflectance.tif output=Oa10_reflectance --o --quiet
+r.external input=${OUTFOLDER}/${DATE}/Oa11_reflectance.tif output=Oa11_reflectance --o --quiet
+r.external input=${OUTFOLDER}/${DATE}/Oa17_reflectance.tif output=Oa17_reflectance --o --quiet
+r.external input=${OUTFOLDER}/${DATE}/Oa21_reflectance.tif output=Oa21_reflectance --o --quiet
+
+# uses mosaic to calculate broadband albedo using empirical approach
+r.mapcalc "BBA_empirical = min((Oa01_reflectance + Oa06_reflectance + Oa17_reflectance + Oa21_reflectance) / 4.0 * 0.945 + 0.055,1)" --o 
+r.out.gdal --overwrite -m -c input=BBA_empirical output=${OUTFOLDER}/${DATE}/BBA_empirical.tif
+
+# uses mosaic to calculate algal cellcount using empirical approach
+ r.mapcalc "C_algea_empirical = 10^7 * (log(Oa11_reflectance / Oa10_reflectance))^2" --o
+ r.out.gdal --overwrite -m -c input=C_algea_empirical output=${OUTFOLDER}/${DATE}/C_algea_empirical.tif
 
 # combine bands to make RGB
-echo "Writing out RGB and SZA_LUT"
+# echo "Writing out RGB and SZA_LUT"
 
 # gdaldem color-relief $(g.list type=raster | head -n1)  col.txt ${OUTFOLDER}/${DATE}/thumb.jpeg -of JPEG -s 0.05
 # r.composite -d -c blue=Oa04_reflectance green=Oa06_reflectance red=Oa08_reflectance output=RGB --o

--- a/dm.sh
+++ b/dm.sh
@@ -9,7 +9,6 @@ DATE=$1      # YYYYMMDD
 INFOLDER=$2  # ./tmp ?
 OUTFOLDER=$3 # ./mosaic ?
 
-grass -e -c mask.tif ./G_mosaic_$$ # work in ./G_mosaic_<PSEUDO_RANDOM>
-grass ./G_mosaic_$$/PERMANENT --exec ./dm.grass.sh $DATE $INFOLDER $OUTFOLDER
-# rm -fR ./G_mosaic_$$ # cleanup
-
+grass -e -c mask.tif ~/G_mosaic_$$ # work in ./G_mosaic_<PSEUDO_RANDOM>
+grass ~/G_mosaic_$$/PERMANENT --exec ./dm.grass.sh $DATE $INFOLDER $OUTFOLDER
+rm -fR ~/G_mosaic_$$ # cleanup

--- a/xml/S3_proc_fast.xml
+++ b/xml/S3_proc_fast.xml
@@ -118,49 +118,7 @@
       <formatName>GeoTIFF</formatName>
     </parameters>
   </node>
-  <!--
-  <node id="BandSelect_02">
-    <operator>BandSelect</operator>
-    <sources><source>Rad2Refl</source></sources>
-    <parameters><sourceBands>Oa02_reflectance</sourceBands></parameters>
-  </node>
-  <node id="Write_02">
-    <operator>Write</operator>
-    <sources><sourceProduct>BandSelect_02</sourceProduct></sources>
-    <parameters>
-      <file>${targetFolder}/Oa02_reflectance_x.tif</file>
-      <formatName>GeoTIFF</formatName>
-    </parameters>
-  </node>
   
-  <node id="BandSelect_04">
-    <operator>BandSelect</operator>
-    <sources><source>Reproject</source></sources>
-    <parameters><sourceBands>Oa04_reflectance</sourceBands></parameters>
-  </node>
-  <node id="Write_04">
-    <operator>Write</operator>
-    <sources><sourceProduct>BandSelect_04</sourceProduct></sources>
-    <parameters>
-      <file>${targetFolder}/Oa04_reflectance_x.tif</file>
-      <formatName>GeoTIFF</formatName>
-    </parameters>
-  </node>
-
-  <node id="BandSelect_05">
-    <operator>BandSelect</operator>
-    <sources><source>Rad2Refl</source></sources>
-    <parameters><sourceBands>Oa05_reflectance</sourceBands></parameters>
-  </node>
-  <node id="Write_05">
-    <operator>Write</operator>
-    <sources><sourceProduct>BandSelect_05</sourceProduct></sources>
-    <parameters>
-      <file>${targetFolder}/Oa05_reflectance_x.tif</file>
-      <formatName>GeoTIFF</formatName>
-    </parameters>
-  </node>
-
   <node id="BandSelect_06">
     <operator>BandSelect</operator>
     <sources><source>Reproject</source></sources>
@@ -174,80 +132,40 @@
       <formatName>GeoTIFF</formatName>
     </parameters>
   </node>
+  
 
-  <node id="BandSelect_08">
+  <node id="BandSelect_10">
     <operator>BandSelect</operator>
     <sources><source>Reproject</source></sources>
-    <parameters><sourceBands>Oa08_reflectance</sourceBands></parameters>
+    <parameters><sourceBands>Oa10_reflectance</sourceBands></parameters>
   </node>
-  <node id="Write_08">
+  <node id="Write_10">
     <operator>Write</operator>
-    <sources><sourceProduct>BandSelect_08</sourceProduct></sources>
+    <sources><sourceProduct>BandSelect_10</sourceProduct></sources>
     <parameters>
-      <file>${targetFolder}/Oa08_reflectance_x.tif</file>
+      <file>${targetFolder}/Oa10_reflectance_x.tif</file>
       <formatName>GeoTIFF</formatName>
     </parameters>
   </node>
 
-  <node id="BandSelect_09">
+  <node id="BandSelect_11">
     <operator>BandSelect</operator>
-    <sources><source>Rad2Refl</source></sources>
-    <parameters><sourceBands>Oa09_reflectance</sourceBands></parameters>
+    <sources><source>Reproject</source></sources>
+    <parameters><sourceBands>Oa11_reflectance</sourceBands></parameters>
   </node>
-  <node id="Write_09">
+  <node id="Write_11">
     <operator>Write</operator>
-    <sources><sourceProduct>BandSelect_09</sourceProduct></sources>
+    <sources><sourceProduct>BandSelect_11</sourceProduct></sources>
     <parameters>
-      <file>${targetFolder}/Oa09_reflectance_x.tif</file>
+      <file>${targetFolder}/Oa11_reflectance_x.tif</file>
       <formatName>GeoTIFF</formatName>
     </parameters>
   </node>
-
-  <node id="BandSelect_13">
-    <operator>BandSelect</operator>
-    <sources><source>Rad2Refl</source></sources>
-    <parameters><sourceBands>Oa13_reflectance</sourceBands></parameters>
-  </node>
-  <node id="Write_13">
-    <operator>Write</operator>
-    <sources><sourceProduct>BandSelect_13</sourceProduct></sources>
-    <parameters>
-      <file>${targetFolder}/Oa13_reflectance_x.tif</file>
-      <formatName>GeoTIFF</formatName>
-    </parameters>
-  </node>
-
-  <node id="BandSelect_14">
-    <operator>BandSelect</operator>
-    <sources><source>Rad2Refl</source></sources>
-    <parameters><sourceBands>Oa14_reflectance</sourceBands></parameters>
-  </node>
-  <node id="Write_14">
-    <operator>Write</operator>
-    <sources><sourceProduct>BandSelect_14</sourceProduct></sources>
-    <parameters>
-      <file>${targetFolder}/Oa14_reflectance_x.tif</file>
-      <formatName>GeoTIFF</formatName>
-    </parameters>
-  </node>
-
-  <node id="BandSelect_15">
-    <operator>BandSelect</operator>
-    <sources><source>Rad2Refl</source></sources>
-    <parameters><sourceBands>Oa15_reflectance</sourceBands></parameters>
-  </node>
-  <node id="Write_15">
-    <operator>Write</operator>
-    <sources><sourceProduct>BandSelect_15</sourceProduct></sources>
-    <parameters>
-      <file>${targetFolder}/Oa15_reflectance_x.tif</file>
-      <formatName>GeoTIFF</formatName>
-    </parameters>
-  </node>
-
+  
+  
   <node id="BandSelect_17">
     <operator>BandSelect</operator>
-    <sources><source>Rad2Refl</source></sources>
+    <sources><source>Reproject</source></sources>
     <parameters><sourceBands>Oa17_reflectance</sourceBands></parameters>
   </node>
   <node id="Write_17">
@@ -258,7 +176,7 @@
       <formatName>GeoTIFF</formatName>
     </parameters>
   </node>
--->
+
   <node id="BandSelect_21">
     <operator>BandSelect</operator>
     <sources><source>Reproject</source></sources>

--- a/xml/SICE_preproc.xml
+++ b/xml/SICE_preproc.xml
@@ -171,6 +171,17 @@
       <formatName>CSV</formatName>
     </parameters>
   </node>
+  
+    <node id="Write_01_tif">
+    <operator>Write</operator>
+    <sources>
+      <sourceProduct>BandSelect_01</sourceProduct>
+    </sources>
+    <parameters>
+      <file>${targetFolder}/Oa01_reflectance_x.tif</file>
+      <formatName>GeoTIFF</formatName>
+    </parameters>
+  </node>
 
   <node id="BandSelect_02">
     <operator>BandSelect</operator>
@@ -260,6 +271,17 @@
     </parameters>
   </node>
 
+  <node id="Write_06_tif">
+    <operator>Write</operator>
+    <sources>
+      <sourceProduct>BandSelect_06</sourceProduct>
+    </sources>
+    <parameters>
+      <file>${targetFolder}/Oa06_reflectance_x.tif</file>
+      <formatName>GeoTIFF</formatName>
+    </parameters>
+  </node>
+    
   <node id="BandSelect_07">
     <operator>BandSelect</operator>
     <sources>
@@ -445,6 +467,7 @@
       <sourceBands>Oa17_reflectance</sourceBands>
     </parameters>
   </node>
+  
   <node id="Write_17">
     <operator>Write</operator>
     <sources>
@@ -455,7 +478,18 @@
       <formatName>CSV</formatName>
     </parameters>
   </node>
-
+  
+    <node id="Write_17_tif">
+    <operator>Write</operator>
+    <sources>
+      <sourceProduct>BandSelect_17</sourceProduct>
+    </sources>
+    <parameters>
+      <file>${targetFolder}/Oa17_reflectance_x.tif</file>
+      <formatName>GeoTIFF</formatName>
+    </parameters>
+  </node>
+  
   <node id="BandSelect_18">
     <operator>BandSelect</operator>
     <sources>
@@ -530,6 +564,16 @@
     </parameters>
   </node>
 
+  <node id="Write_21_tif">
+    <operator>Write</operator>
+    <sources>
+      <sourceProduct>BandSelect_21</sourceProduct>
+    </sources>
+    <parameters>
+      <file>${targetFolder}/Oa21_reflectance_x.tif</file>
+      <formatName>GeoTIFF</formatName>
+    </parameters>
+  </node>
 
   <!--
       SZA, SAA, OZA, OAA

--- a/xml/cloud.xml
+++ b/xml/cloud.xml
@@ -11,7 +11,7 @@
   -->
   
   <node id="CloudID">
-    <operator>Snap.Idepix.Olci.S3Snow</operator>
+    <operator>Idepix.Olci</operator>
     <sources>
       <sourceProduct>${source}</sourceProduct>
     </sources>

--- a/xml/cloud_new.xml
+++ b/xml/cloud_new.xml
@@ -1,18 +1,36 @@
-<graph id="cloud">
+<graph id="Graph">
   <version>1.0</version>
+  <node id="Read">
+    <operator>Read</operator>
+    <sources/>
+    <parameters >
+      <file>${pathfile}</file>
+      <formatName>Sen3</formatName>
+    </parameters>
+  </node>
 
-  
-  <node id="CloudID">
-    <operator>Snap.Idepix.Olci.S3Snow</operator>
+  <node id="Idepix.Olci">
+    <operator>Idepix.Olci</operator>
     <sources>
-      <sourceProduct>${source}</sourceProduct>
+      <sourceProduct refid="Read"/>
     </sources>
+    <parameters >
+      <radianceBandsToCopy/>
+      <reflBandsToCopy/>
+      <outputSchillerNNValue>false</outputSchillerNNValue>
+      <computeCloudShadow>true</computeCloudShadow>
+      <alternativeNNDirPath/>
+      <outputCtp>false</outputCtp>
+      <computeCloudBuffer>true</computeCloudBuffer>
+      <cloudBufferWidth>2</cloudBufferWidth>
+      <useSrtmLandWaterMask>false</useSrtmLandWaterMask>
+    </parameters>
   </node>
 
   <node id="Reproject">
     <operator>Reproject</operator>
     <sources>
-      <source>CloudID</source>
+      <sourceProduct refid="Idepix.Olci"/>
     </sources>
     <parameters>
       <crs>EPSG:3413</crs>
@@ -22,26 +40,37 @@
     </parameters>
   </node>
 
-  <node id="BandSelect_cloud01">
-    <operator>BandSelect</operator>
+  <node id="BandMaths">
+    <operator>BandMaths</operator>
     <sources>
-      <source>Reproject</source>
+      <sourceProduct refid="Reproject"/>
     </sources>
-    <parameters>
-      <sourceBands>cloud_over_snow</sourceBands>
+    <parameters >
+      <targetBands>
+        <targetBand>
+          <name>newBand</name>
+          <type>float32</type>
+          <expression>IDEPIX_CLOUD</expression>
+          <description/>
+          <unit/>
+          <noDataValue>-999.0</noDataValue>
+        </targetBand>
+      </targetBands>
+      <variables/>
     </parameters>
   </node>
-  
-  <node id="Write_cloud01">
+
+
+  <node id="Write_CloudID">
     <operator>Write</operator>
     <sources>
-      <sourceProduct>BandSelect_cloud01</sourceProduct>
+      <sourceProduct>BandMaths</sourceProduct>
     </sources>
     <parameters>
-      <file>${targetFolder}/cloud_over_snow_x.tif</file>
+      <file>${targetFolder}/idepix_cloud.tif</file>
       <formatName>GeoTIFF</formatName>
     </parameters>
   </node>
-  
-  
+
+
 </graph>


### PR DESCRIPTION
dm.grass.sh
- added some projection information
- added a line for the code to work in the absence of cloud mask (if idepix_cloud_ambiguous is missing)
- calculates broadband albedo and algea cell count from Jason's empirical functions on the final mosaics

dm.sh
- on my vm the working folder is shared with the host system and it bothers grass. In the new version G_mosaic is placed in "~"

Readme.org
- added some info. Will need some editing.

S3_proc.sh
- now that the empirical outputs will be calculated using SNAP-generated tifs, the tiff compressing needs to happen anyway

cloud.xml and cloud_new.xml
- updated processor name for SNAP7. But Idepix still does not function.

S3_proc_fast.xml
- added the output of Geotif reflectance grids used by the emprical formulas

SICE_preproc.xml
- added the output of Geotif reflectance grids used by the emprical formulas